### PR TITLE
Let the user cancel FreeRDP authentication and dismiss the dialog window

### DIFF
--- a/plugins/rdp/vinagre-rdp-tab.c
+++ b/plugins/rdp/vinagre-rdp-tab.c
@@ -1218,7 +1218,7 @@ open_freerdp (VinagreRdpTab *rdp_tab)
           init_freerdp (rdp_tab);
         }
     }
-  while (!success && authentication_errors < 3);
+  while (!success && !cancelled && authentication_errors < 3);
 
   if (!success)
     {


### PR DESCRIPTION
If the user hits the cancel button of the FreeRDP authentication dialog,
it is dismissed and then created again in an endless loop.